### PR TITLE
fix: add publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,5 +108,8 @@
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown",
     "*.{ts,tsx}": "eslint --fix --max-warnings 0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Adds `publishConfig.access = public` to this package

Ticket: VL-1844