### PR TITLE
fix: change scope from `@bitgo` to `@bitgo-forks`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bitgo/avalanchejs",
+  "name": "@bitgo-forks/avalanchejs",
   "version": "4.0.5",
   "description": "Avalanche Platform JS Library",
   "main": "dist/index.cjs",


### PR DESCRIPTION
Rather than publishing to the `@bitgo` npm org, it will be safer to publish to the `@bitgo-forks` org.